### PR TITLE
feat(hanwha): 예매 탭 하위 탭 분리 (캘린더·티켓팅·취소표)

### DIFF
--- a/hanwha/index.html
+++ b/hanwha/index.html
@@ -129,7 +129,13 @@
         </div>
       </section>
 
-      <section class="section-grid" id="tickets" data-view-panel="tickets">
+      <nav class="tickets-subnav" data-view-panel="tickets" aria-label="예매 하위 메뉴" role="tablist">
+        <button class="active" type="button" data-tickets-tab="calendar" role="tab" aria-selected="true">캘린더</button>
+        <button type="button" data-tickets-tab="info" role="tab" aria-selected="false">티켓팅</button>
+        <button type="button" data-tickets-tab="cancel" role="tab" aria-selected="false">취소표</button>
+      </nav>
+
+      <section class="section-grid" id="tickets" data-view-panel="tickets" data-tickets-tab="info">
         <div class="section-heading">
           <div>
             <p class="eyebrow">Ticketing</p>
@@ -139,7 +145,7 @@
         <div class="ticket-game-list" id="ticketGameList"></div>
       </section>
 
-      <section class="section-grid" id="cancel-watch" data-view-panel="tickets">
+      <section class="section-grid" id="cancel-watch" data-view-panel="tickets" data-tickets-tab="cancel">
         <div class="section-heading">
           <div>
             <p class="eyebrow">Cancel Ticket Concierge</p>
@@ -153,7 +159,7 @@
         <div class="cancel-watch-list" id="cancelWatchList"></div>
       </section>
 
-      <section class="section-grid" id="calendar" data-view-panel="tickets">
+      <section class="section-grid" id="calendar" data-view-panel="tickets" data-tickets-tab="calendar">
         <div class="section-heading">
           <div>
             <p class="eyebrow">Ticket Calendar</p>

--- a/hanwha/script.js
+++ b/hanwha/script.js
@@ -1400,6 +1400,30 @@ window.addEventListener("popstate", () => {
   setActiveView(viewFromHash(), false);
 });
 
+// 예매 탭 하위 탭(캘린더/티켓팅/취소표) — 메인 라우팅의 hidden 과 독립된 클래스 레이어.
+const TICKETS_DEFAULT_TAB = "calendar";
+
+function applyTicketsSubTab(tab) {
+  document.querySelectorAll("[data-tickets-tab]").forEach((el) => {
+    const match = el.dataset.ticketsTab === tab;
+    if (el.tagName === "BUTTON") {
+      el.classList.toggle("active", match);
+      el.setAttribute("aria-selected", String(match));
+    } else {
+      el.classList.toggle("is-subhidden", !match);
+    }
+  });
+}
+
+document.querySelectorAll(".tickets-subnav [data-tickets-tab]").forEach((button) => {
+  button.addEventListener("click", () => {
+    applyTicketsSubTab(button.dataset.ticketsTab);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+});
+
+applyTicketsSubTab(TICKETS_DEFAULT_TAB);
+
 document.querySelectorAll("[data-game-filter]").forEach((button) => {
   button.addEventListener("click", () => {
     setActiveButton(document.querySelectorAll("[data-game-filter]"), button);

--- a/hanwha/styles.css
+++ b/hanwha/styles.css
@@ -2091,3 +2091,62 @@ h2 {
   color: var(--muted);
   line-height: 1.6;
 }
+
+/* ===========================================================================
+   [v23] 예매 탭 하위 탭 (캘린더 / 티켓팅 / 취소표) — 한 번에 하나만 노출
+   =========================================================================== */
+.tickets-subnav {
+  width: min(1180px, calc(100% - 40px));
+  margin: 24px auto 0;
+  display: flex;
+  gap: 6px;
+  padding: 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  background: var(--surface-strong);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tickets-subnav::-webkit-scrollbar {
+  display: none;
+}
+.tickets-subnav button {
+  flex: 1 1 auto;
+  min-height: 42px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 800;
+  font-size: 0.94rem;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.tickets-subnav button:hover {
+  color: var(--text);
+}
+.tickets-subnav button.active {
+  background: var(--grad-accent);
+  color: var(--on-accent);
+  box-shadow: var(--glow);
+}
+
+/* 하위 탭 패널: 상단 여백 축소(서브내비가 맥락 제공) + 비활성 숨김 */
+.section-grid[data-tickets-tab] {
+  padding-top: clamp(28px, 4vw, 40px);
+}
+.section-grid.is-subhidden {
+  display: none;
+}
+
+@media (max-width: 620px) {
+  .tickets-subnav {
+    width: calc(100% - 24px);
+  }
+  .tickets-subnav button {
+    padding: 0 12px;
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## 요약

예매 탭에 3개 섹션(티켓팅 정보·취소표 컨시어지·10구단 예매 캘린더)이 세로로 쌓여 너무 길던 문제를, **세그먼트 하위 탭**으로 분리해 한 번에 하나만 노출.

- `캘린더 · 티켓팅 · 취소표` 하위 탭 (기본=캘린더)
- 메인 뷰 라우팅(`data-view-panel`)의 `hidden` 속성과 독립된 `.is-subhidden` 클래스 레이어 → 충돌 없음, 탭 이탈→복귀 시 선택 유지
- 활성 탭은 accent 그라디언트, 모바일 가로 스크롤 대응

## 검증
- `npm run check` 31/31
- 모바일 375 / 데스크톱 1280 × 다크/라이트: 캘린더↔티켓팅↔취소표 전환, 다른 뷰 갔다 복귀 시 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)