### PR TITLE
feat(hanwha): 홈 예매오픈 카운트다운 카드 + 검증 신호 보강(N4)

### DIFF
--- a/hanwha/index.html
+++ b/hanwha/index.html
@@ -35,7 +35,7 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700;800;900&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=21" />
+    <link rel="stylesheet" href="./styles.css?v=22" />
   </head>
   <body>
     <header class="topbar">
@@ -92,6 +92,8 @@
           </div>
         </div>
       </section>
+
+      <section class="ticket-open-card section-grid" id="ticketOpenCard" data-view-panel="home" aria-label="다음 예매 오픈"></section>
 
       <section class="snapshot" id="summaryBoard" aria-label="팀 요약" data-view-panel="home">
         <article>
@@ -246,6 +248,6 @@
       </p>
     </footer>
 
-    <script src="./script.js?v=22"></script>
+    <script src="./script.js?v=23"></script>
   </body>
 </html>

--- a/hanwha/offline.html
+++ b/hanwha/offline.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0b0e" />
     <title>KBO TIDO | 오프라인</title>
-    <link rel="stylesheet" href="./styles.css?v=21" />
+    <link rel="stylesheet" href="./styles.css?v=22" />
   </head>
   <body class="offline-page">
     <main class="offline-shell">

--- a/hanwha/script.js
+++ b/hanwha/script.js
@@ -207,6 +207,7 @@ const teamStandingsBoard = document.querySelector("#teamStandingsBoard");
 const gameList = document.querySelector("#gameList");
 const featuredGame = document.querySelector("#featuredGame");
 const ticketGameList = document.querySelector("#ticketGameList");
+const ticketOpenCard = document.querySelector("#ticketOpenCard");
 const ticketCalendarFilters = document.querySelector("#ticketCalendarFilters");
 const ticketCalendarList = document.querySelector("#ticketCalendarList");
 const cancelWatchList = document.querySelector("#cancelWatchList");
@@ -665,10 +666,15 @@ function topDemandEntry(bucket) {
 
 function demandMetricCards(signals) {
   const permissionTotal = Object.values(signals.permissionResults).reduce((sum, count) => sum + count, 0);
+  // 취소표(cancel_watch_*) 신호를 누락 없이 합산해 한 카드로 노출.
+  const cancelWatchTotal = Object.entries(signals.eventCounts)
+    .filter(([name]) => name.startsWith("cancel_watch_"))
+    .reduce((sum, [, count]) => sum + count, 0);
   const metrics = [
     ["알림 저장", signals.eventCounts.ticket_reminder_saved ?? 0, topDemandEntry(signals.teams)],
     ["예매처 클릭", signals.eventCounts.provider_click ?? 0, topDemandEntry(signals.providers)],
     ["구단 필터", signals.eventCounts.calendar_filter_selected ?? 0, topDemandEntry(signals.teams)],
+    ["취소표 관심", cancelWatchTotal, topDemandEntry(signals.providers)],
     ["알림 권한", permissionTotal, topDemandEntry(signals.permissionResults)],
   ];
 
@@ -689,7 +695,10 @@ function renderDemandSignals() {
   }
 
   const signals = readDemandSignals();
-  demandSignalBoard.innerHTML = demandMetricCards(signals);
+  demandSignalBoard.innerHTML = html`
+    ${demandMetricCards(signals)}
+    <p class="demand-scope-note">이 수치는 현재 기기 기준 · 전체 합산은 백엔드 도입(다음 단계) 후 제공</p>
+  `;
   demandSignalEvents.innerHTML = html`
     <div class="section-heading compact">
       <div>
@@ -882,6 +891,147 @@ function renderTicketInfo(game, featured = false) {
       </div>
     </div>
   `;
+}
+
+// 홈 카운트다운 카드 — 다음 예매 오픈이 가장 가까운 내 구단 경기 1개.
+let ticketOpenCountdownTimer = null;
+let ticketOpenCountdownTarget = null;
+
+function pickNextTicketOpenGame() {
+  // selectedTeam 이 홈/원정으로 참여하는 다가오는(upcoming) 경기 중,
+  // 예매 오픈 시각이 아직 안 열렸으면 우선, 그 안에서 가장 가까운 1개.
+  const now = Date.now();
+  const candidates = selectedTeamGames()
+    .filter((game) => game.type === "upcoming")
+    .map((game) => {
+      const ticketing = getTicketing(game);
+      const openInfo = getTicketOpenInfo(game, ticketing);
+      return { game, ticketing, openInfo };
+    })
+    .filter(({ openInfo }) => openInfo.openAt instanceof Date);
+
+  // 아직 안 열린 경기 우선(오픈 임박 순), 없으면 이미 열린 경기 중 오픈 최신 순.
+  const upcoming = candidates
+    .filter(({ openInfo }) => !openInfo.isOpen)
+    .sort((a, b) => a.openInfo.openAt - b.openInfo.openAt)[0];
+  if (upcoming) {
+    return upcoming;
+  }
+  return candidates
+    .filter(({ openInfo }) => openInfo.isOpen && openInfo.openAt.getTime() <= now)
+    .sort((a, b) => b.openInfo.openAt - a.openInfo.openAt)[0] ?? null;
+}
+
+function formatCountdown(ms) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const days = Math.floor(total / 86400);
+  const hh = String(Math.floor((total % 86400) / 3600)).padStart(2, "0");
+  const mm = String(Math.floor((total % 3600) / 60)).padStart(2, "0");
+  const ss = String(total % 60).padStart(2, "0");
+  return { days, clock: `${hh}:${mm}:${ss}` };
+}
+
+function tickTicketOpenCountdown() {
+  if (!ticketOpenCard || !ticketOpenCountdownTarget) {
+    return;
+  }
+
+  const el = ticketOpenCard.querySelector(".toc-countdown");
+  if (!el) {
+    return;
+  }
+
+  const remain = ticketOpenCountdownTarget.getTime() - Date.now();
+  if (remain <= 0) {
+    // 오픈 시각 도달 → 상태 전환 위해 카드 재렌더(인터벌 자동 정리).
+    renderTicketOpenCard();
+    return;
+  }
+
+  const { days, clock } = formatCountdown(remain);
+  el.textContent = days > 0 ? `D-${days} · ${clock}` : clock;
+
+  // 오픈 ≤ 1시간이면 임박 강조(임계점을 카운트다운 도중 넘으면 켜진다).
+  const soon = remain <= 60 * 60 * 1000;
+  el.classList.toggle("is-soon", soon);
+  ticketOpenCard.classList.toggle("is-soon", soon);
+}
+
+function stopTicketOpenCountdown() {
+  if (ticketOpenCountdownTimer) {
+    window.clearInterval(ticketOpenCountdownTimer);
+    ticketOpenCountdownTimer = null;
+  }
+}
+
+function startTicketOpenCountdown(target) {
+  stopTicketOpenCountdown();
+  ticketOpenCountdownTarget = target;
+  if (!target || document.hidden) {
+    return;
+  }
+  tickTicketOpenCountdown();
+  ticketOpenCountdownTimer = window.setInterval(tickTicketOpenCountdown, 1000);
+}
+
+function renderTicketOpenCard() {
+  if (!ticketOpenCard) {
+    return;
+  }
+
+  stopTicketOpenCountdown();
+  ticketOpenCountdownTarget = null;
+
+  const pick = pickNextTicketOpenGame();
+
+  if (!pick) {
+    ticketOpenCard.classList.remove("is-soon", "toc-open");
+    ticketOpenCard.innerHTML = html`
+      <div class="toc-empty">
+        <span class="toc-eyebrow">다음 예매 오픈</span>
+        <p class="meta">${selectedTeam} 의 다가오는 예매 오픈 경기가 없습니다. 예매 캘린더에서 일정을 확인하세요.</p>
+      </div>
+    `;
+    return;
+  }
+
+  const { game, ticketing, openInfo } = pick;
+  const reminderOn = Boolean(getTicketReminders()[gameId(game)]);
+  const isOpen = openInfo.isOpen;
+  const remain = openInfo.openAt.getTime() - Date.now();
+  const soon = !isOpen && remain <= 60 * 60 * 1000;
+  const alertLabel = reminderOn ? "알림 설정됨" : openInfo.canRemind ? "알림 받기" : "오픈 임박";
+  const canClickReminder = reminderOn || openInfo.canRemind;
+  const { days, clock } = formatCountdown(Math.max(0, remain));
+  const countdownText = isOpen ? "예매 중" : days > 0 ? `D-${days} · ${clock}` : clock;
+
+  ticketOpenCard.classList.toggle("is-soon", soon);
+  ticketOpenCard.classList.toggle("toc-open", isOpen);
+
+  ticketOpenCard.innerHTML = html`
+    <span class="toc-eyebrow">다음 예매 오픈</span>
+    <strong class="toc-matchup">${game.away} vs ${game.home}</strong>
+    <p class="toc-meta">${game.date} ${game.time} · ${game.location} · ${ticketing.venueType} ${ticketing.provider} · ${openInfo.openText}</p>
+    <div class="toc-countdown ${raw(soon ? "is-soon" : "")} ${raw(isOpen ? "toc-open" : "")}" aria-live="polite">${countdownText}</div>
+    <div class="toc-actions">
+      <a
+        href="${ticketing.url}"
+        target="_blank"
+        rel="noopener"
+        data-demand-action="provider-click"
+        data-demand-provider="${ticketing.provider}"
+        data-demand-team="${game.home}"
+        data-demand-source="home-card"
+      >예매처</a>
+      <button class="${raw(reminderOn ? "is-on" : "")}" type="button" data-ticket-alert="${gameId(game)}" ${raw(canClickReminder ? "" : "disabled")}>
+        ${alertLabel}
+      </button>
+    </div>
+  `;
+
+  if (!isOpen) {
+    startTicketOpenCountdown(openInfo.openAt);
+  }
 }
 
 function renderCancelWatch() {
@@ -1280,6 +1430,7 @@ function refreshSelectedTeamViews() {
   renderLiveGame();
   renderGames(currentGameFilter());
   renderTickets();
+  renderTicketOpenCard();
 }
 
 function renderAll() {
@@ -1291,6 +1442,7 @@ function renderAll() {
   renderTickets();
   renderTicketCalendar();
   renderCancelWatch();
+  renderTicketOpenCard();
   renderPlayers(currentPlayerFilter());
   renderDemandSignals();
 }
@@ -1645,6 +1797,7 @@ async function enableTicketReminder(gameKey, source = "unknown") {
   renderGames(document.querySelector("[data-game-filter].active")?.dataset.gameFilter ?? "recent");
   renderTickets();
   renderTicketCalendar();
+  renderTicketOpenCard();
   trackDemandSignal("ticket_reminder_saved", { team: game.home, provider: ticketing.provider, source });
   showToast(`${formatKstDateTime(new Date(reminder.remindAt))} 티켓 알림을 저장했습니다.`);
 
@@ -1843,9 +1996,14 @@ if ("serviceWorker" in navigator && location.protocol.startsWith("http")) {
 }
 
 document.addEventListener("visibilitychange", () => {
-  if (!document.hidden) {
-    pollData();
+  if (document.hidden) {
+    // 숨김 동안 1초 인터벌 정지(배터리/연산 절약).
+    stopTicketOpenCountdown();
+    return;
   }
+  pollData();
+  // 복귀 시 카드 재렌더로 상태/카운트다운을 현재 시각 기준으로 재개.
+  renderTicketOpenCard();
 });
 
 updateNotifyButton();

--- a/hanwha/service-worker.js
+++ b/hanwha/service-worker.js
@@ -1,10 +1,10 @@
-const CACHE_NAME = "eagles-lounge-v24";
+const CACHE_NAME = "eagles-lounge-v25";
 const APP_SHELL = [
   "./",
   "./index.html",
   "./offline.html",
-  "./styles.css?v=21",
-  "./script.js?v=22",
+  "./styles.css?v=22",
+  "./script.js?v=23",
   "./manifest.webmanifest",
   "./assets/app-icon.svg",
   "./assets/hero-stadium.png",

--- a/hanwha/styles.css
+++ b/hanwha/styles.css
@@ -2150,3 +2150,253 @@ h2 {
     font-size: 0.9rem;
   }
 }
+
+/* ===========================================================================
+   [v25] 홈 예매오픈 카운트다운 + 검증 고지
+   토큰만 사용 · 라이트/다크 공통 · 기존 규칙 재작성 없이 APPEND.
+   #live 와 #summaryBoard 사이 카드 1개. 내부는 JS가 계약 클래스로 렌더.
+   =========================================================================== */
+
+/* ── 카드 컨테이너: 기존 카드 톤(소프트 섀도) + 상단 액센트 라인 ── */
+.ticket-open-card {
+  position: relative;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+    border-color 0.18s ease;
+}
+
+/* 상단 강조 라인 (그라데이션 액센트) */
+.ticket-open-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: var(--grad-accent);
+  opacity: 0.85;
+}
+
+.ticket-open-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+/* ── 라벨(eyebrow 톤) ── */
+.toc-eyebrow {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent-strong);
+  font-weight: 900;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.toc-eyebrow::before {
+  content: "";
+  width: 18px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--grad-accent);
+}
+
+/* ── 경기 매치업: 굵게 ── */
+.toc-matchup {
+  margin: 0;
+  font-weight: 900;
+  font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+  line-height: 1.2;
+}
+
+/* ── 메타(일시·구장·예매처): muted 작은 글씨 + 구분점 ── */
+.toc-meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 8px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+.toc-meta > * + *::before {
+  content: "·";
+  margin-right: 8px;
+  color: var(--line);
+}
+
+/* ── 카운트다운: display 폰트 + tnum, 큰 숫자, accent-2 ── */
+.toc-countdown {
+  margin: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--font-display);
+  font-feature-settings: "tnum" 1;
+  font-variant-numeric: tabular-nums;
+  font-weight: 900;
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+  line-height: 1;
+  color: var(--accent-2);
+  letter-spacing: 0.01em;
+}
+
+/* ── 액션 그룹: 알약 버튼/링크 (ticket-actions 톤) ── */
+.toc-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.toc-actions a,
+.toc-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 16px;
+  border-radius: var(--radius-pill);
+  font-size: 0.82rem;
+  font-weight: 900;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+/* 예매처 링크: 아웃라인 알약 */
+.toc-actions a {
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--line));
+  background: var(--surface);
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+.toc-actions a:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+}
+
+/* 알림 토글: surface-2 기본 → is-on 시 그라데이션 + 글로우 */
+.toc-actions button {
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.toc-actions button:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+.toc-actions button.is-on {
+  border-color: transparent;
+  background: var(--grad-accent);
+  color: var(--on-accent);
+  box-shadow: var(--glow);
+}
+.toc-actions button.is-on:hover {
+  color: var(--on-accent);
+}
+.toc-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
+}
+
+.toc-actions a:focus-visible,
+.toc-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── is-soon: 오픈 임박(≤1h) 강조 보더/글로우 + 펄스 ── */
+.ticket-open-card.is-soon {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  box-shadow: var(--glow), var(--shadow-soft);
+  animation: toc-soon-pulse 2s ease-in-out infinite;
+}
+.ticket-open-card.is-soon::before {
+  opacity: 1;
+}
+.ticket-open-card.is-soon .toc-countdown {
+  color: var(--accent);
+}
+
+@keyframes toc-soon-pulse {
+  0%,
+  100% {
+    box-shadow: var(--glow), var(--shadow-soft);
+  }
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent),
+      var(--shadow-soft);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ticket-open-card.is-soon {
+    animation: none;
+  }
+}
+
+/* ── toc-open: 이미 예매중 칩 느낌 ── */
+.toc-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  width: fit-content;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* ── toc-empty: 점선 박스 빈 상태 ── */
+.toc-empty {
+  margin: 0;
+  padding: 18px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* ── 검증 탭 고지(N4): muted 작은 텍스트, 살짝 들여쓰기 ── */
+.demand-scope-note {
+  margin: 10px 0 0;
+  padding-left: 2px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+/* ── 모바일(≤619px): 카운트다운·액션 줄바꿈, 패딩 축소 ── */
+@media (max-width: 619px) {
+  .ticket-open-card {
+    padding: 17px 16px;
+    gap: 10px;
+  }
+  .toc-countdown {
+    flex-wrap: wrap;
+    gap: 4px 8px;
+  }
+  .toc-actions {
+    width: 100%;
+  }
+  .toc-actions a,
+  .toc-actions button {
+    flex: 1 1 auto;
+  }
+}

--- a/hanwha/tests/pwa-registration.test.mjs
+++ b/hanwha/tests/pwa-registration.test.mjs
@@ -27,7 +27,7 @@ test("app shell and data loader include ticketing calendar", async () => {
   assert.match(script, /ticketCalendar:\s*\[\]/);
   assert.match(script, /ticketCalendar:\s*"\.\/data\/ticketing-calendar\.json"/);
   assert.match(script, /fetchJson\(dataFiles\.ticketCalendar\)/);
-  assert.match(serviceWorker, /eagles-lounge-v24/);
+  assert.match(serviceWorker, /eagles-lounge-v25/);
   assert.match(serviceWorker, /\.\/data\/ticketing-calendar\.json\?v=19/);
 });
 


### PR DESCRIPTION
## 요약
ROADMAP Now 버킷 — 백엔드 불요 프론트 증분. 다이나믹 워크플로우(CSS‖JS+HTML 병렬)로 구현.

### 홈 "다음 예매 오픈" 카운트다운 카드
- 내 구단 다가오는 경기의 예매 오픈까지 라이브 카운트다운(`D-n · HH:MM:SS`), 매치업·구장·예매처
- 예매처 딥링크 + "알림 받기"(10분 전) 토글 재사용, 오픈 ≤1h 펄스, 탭 숨김 시 정지
- 기존 오픈시각 계산 재사용(재계산/데이터 조작 없음), 팀 전환 즉시 반영

### N4 검증 신호 보강
- 취소표 관심(cancel_watch_*) 검증 보드 집계 + "이 수치는 현재 기기 기준 · 전체 합산은 백엔드 도입 후" 고지

### 캐시버스팅
- `styles.css ?v=22`, `script.js ?v=23`, `CACHE eagles-lounge-v25` (드리프트 가드 테스트가 index↔SW 정합 강제)

## 검증
- `npm run check` **32/32**
- 브라우저: 카드 렌더·카운트다운 틱(14:31:29→14:30:57)·팀전환(한화↔LG, NOL 예매처)·hidden 정지, CSS 양 테마 computed-style, 콘솔 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)